### PR TITLE
[Room creation] the HS name is wrong when the forum type is selected

### DIFF
--- a/changelog.d/341.bugfix
+++ b/changelog.d/341.bugfix
@@ -1,0 +1,1 @@
+[Room creation] the HS name is wrong when the forum type is selected

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewModel.kt
@@ -108,9 +108,10 @@ class CreateRoomViewModel @AssistedInject constructor(@Assisted private val init
     }
 
     private fun initUserDomain() {
-        val displayName = session.run { getUser(myUserId) }?.toMatrixItem()?.getBestName().orEmpty()
+//        val displayName = session.run { getUser(myUserId) }?.toMatrixItem()?.getBestName().orEmpty()
 
-        setState { copy(userDomain = TchapUtils.getDomainFromDisplayName(displayName)) }
+        // Tchap: Use home server Name for user domain in create room view
+        setState { copy(userDomain = TchapUtils.getHomeServerNameFromMXIdentifier(session.myUserId)) }
     }
 
     private var adminE2EByDefault = true


### PR DESCRIPTION
#341 
![Screenshot_1641378014](https://user-images.githubusercontent.com/15031750/148201725-33d1427e-2de2-48ec-bdbc-adbacd16c1f0.png)

