### PR TITLE
Fix the FCM token error

### DIFF
--- a/changelog.d/402.bugfix
+++ b/changelog.d/402.bugfix
@@ -1,0 +1,1 @@
+Fix the FCM token error breaking the push notifications

--- a/vector/src/fdroid/withpinning/res/xml/network_security_config.xml
+++ b/vector/src/fdroid/withpinning/res/xml/network_security_config.xml
@@ -9,12 +9,4 @@
             <certificates src="@raw/certignaservicesrootca" />
         </trust-anchors>
     </base-config>
-
-    <!-- Allow system certificates for firebase -->
-    <domain-config cleartextTrafficPermitted="false">
-        <domain includeSubdomains="false">firebaseinstallations.googleapis.com</domain>
-        <trust-anchors>
-            <certificates src="system" />
-        </trust-anchors>
-    </domain-config>
 </network-security-config>

--- a/vector/src/gplay/java/im/vector/app/push/fcm/NotificationTroubleshootTestManagerFactory.kt
+++ b/vector/src/gplay/java/im/vector/app/push/fcm/NotificationTroubleshootTestManagerFactory.kt
@@ -49,7 +49,7 @@ class NotificationTroubleshootTestManagerFactory @Inject constructor(
         mgr.addTest(testPlayServices)
         mgr.addTest(testFirebaseToken)
         mgr.addTest(testTokenRegistration)
-        mgr.addTest(testPushFromPushGateway)
+//        mgr.addTest(testPushFromPushGateway)
         mgr.addTest(testNotification)
         return mgr
     }

--- a/vector/src/gplay/java/im/vector/app/push/fcm/NotificationTroubleshootTestManagerFactory.kt
+++ b/vector/src/gplay/java/im/vector/app/push/fcm/NotificationTroubleshootTestManagerFactory.kt
@@ -49,6 +49,7 @@ class NotificationTroubleshootTestManagerFactory @Inject constructor(
         mgr.addTest(testPlayServices)
         mgr.addTest(testFirebaseToken)
         mgr.addTest(testTokenRegistration)
+      // Tchap:  Hide this verification, we can't call tchap server.
 //        mgr.addTest(testPushFromPushGateway)
         mgr.addTest(testNotification)
         return mgr

--- a/vector/src/gplay/withpinning/res/xml/network_security_config.xml
+++ b/vector/src/gplay/withpinning/res/xml/network_security_config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Do not allow clearText traffic -->
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <!-- Do not allow system and user certificates by default -->
+
+            <!-- Allow only Tchap intermediate certificate authority -->
+            <certificates src="@raw/certignaservicesrootca" />
+        </trust-anchors>
+    </base-config>
+
+    <!-- Allow system certificates for firebase -->
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">firebaseinstallations.googleapis.com</domain>
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </domain-config>
+</network-security-config>

--- a/vector/src/withpinning/res/xml/network_security_config.xml
+++ b/vector/src/withpinning/res/xml/network_security_config.xml
@@ -6,7 +6,15 @@
             <!-- Do not allow system and user certificates -->
 
             <!-- Allow only Tchap intermediate certificate authority -->
-            <certificates src="@raw/certignaservicesrootca"/>
+            <certificates src="@raw/certignaservicesrootca" />
         </trust-anchors>
     </base-config>
+
+    <!-- Allow system certificates for firebase -->
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">firebaseinstallations.googleapis.com</domain>
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </domain-config>
 </network-security-config>


### PR DESCRIPTION
#402 

The FCM token could not be retrieved because of the pinning restriction which does not allow the system certificates. These certificates are required to request the FCM token through the firebase API. This PR allows the use of the system certificates for the firebase domain only.

This PR also hide the "Test push" step from the "Troubleshoot Notifications" screen. This step was triggering a notification using the push server `notify` endpoint. The push server has been moved to a new internal sygnal server which is only accessible from the Synapse. This step will be hidden while there is no equivalent public API to trigger a notification. 