### PR TITLE
Fix room name containing brackets cropped

### DIFF
--- a/changelog.d/479.bugfix
+++ b/changelog.d/479.bugfix
@@ -1,0 +1,1 @@
+[Room list] Fix cropped room names containing brackets "[]"

--- a/vector/src/main/java/fr/gouv/tchap/core/utils/TchapUtils.kt
+++ b/vector/src/main/java/fr/gouv/tchap/core/utils/TchapUtils.kt
@@ -90,6 +90,25 @@ object TchapUtils {
     }
 
     /**
+     * Get the room name from a display name according to the given room type.
+     * In the case of a direct message, it will remove the domain part of the display name.
+     * For example in case of "Jean Martin `[Modernisation]`", this will return "Jean Martin".
+     *
+     * Otherwise, it will keep the initial name.
+     *
+     * @param displayName the display name to compute.
+     * @param roomType the room type associated with the given display name.
+     *
+     * @return displayName without domain (or the display name itself if the room is not a DM).
+     */
+    fun getRoomNameFromDisplayName(displayName: String, roomType: TchapRoomType): String {
+        return when (roomType) {
+            TchapRoomType.DIRECT -> getNameFromDisplayName(displayName)
+            else                 -> displayName
+        }
+    }
+
+    /**
      * Get the potential domain name from a display name.
      * For example in case of "Jean Martin `[Modernisation]`", this will return "Modernisation".
      *

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItem.kt
@@ -77,7 +77,7 @@ abstract class RoomSummaryItem : VectorEpoxyModel<RoomSummaryItem.Holder>() {
             itemLongClickListener?.onLongClick(it) ?: false
         }
         // Tchap: remove domain from the display name
-        holder.titleView.text = TchapUtils.getNameFromDisplayName(matrixItem.getBestName())
+        holder.titleView.text = TchapUtils.getRoomNameFromDisplayName(matrixItem.getBestName(), roomType)
         holder.lastEventTimeView.text = lastEventTime
         holder.lastEventView.text = lastFormattedEvent.charSequence
         holder.unreadCounterBadgeView.render(UnreadCounterBadgeView.State(unreadNotificationCount, showHighlighted))


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Added a dedicated method to compute the room name from a display name. The domain part is now removed only for DM, the original display name is kept for the other room types.

## Motivation and context

Room names containing brackets are cropped because the Tchap domain part is removed from the display name in the room list. All the rooms are impacted (whether the room type is a DM or not). The removing of the domain part should only be applied for DMs.

## Screenshots / GIFs

Before:
<img width="881" alt="Capture d’écran 2022-03-09 à 18 05 58" src="https://user-images.githubusercontent.com/11990514/157495244-aaa575e0-869f-4b00-90c3-7e5380bfb345.png">

After:
<img width="890" alt="Capture d’écran 2022-03-09 à 18 05 20" src="https://user-images.githubusercontent.com/11990514/157495336-e7e8b446-24a6-4992-8a49-01aa5f74bd1c.png">

## Tests

- Create or join a room containing brackets (for example `test [room] type`
- Test without the fix -> only the left part is displayed in the room list `room `
- Test after the fix -> all the room name is displayed `test [room] type`
- Verify the other room or user names have not been impacted (for each room type): in the room list, the room details and the room or the user details.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [TCHAP_CHANGES.md](https://github.com/tchapgouv/tchap-android-v2/blob/develop/TCHAP_CHANGES.md)
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android-v2/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
