### PR TITLE
Room list is automatically scrolled to the top after opening a room

### DIFF
--- a/changelog.d/481.bugfix
+++ b/changelog.d/481.bugfix
@@ -1,0 +1,1 @@
+Room list is automatically scrolled to the top after opening a room

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
@@ -187,6 +187,7 @@ class RoomListFragment @Inject constructor(
             }
 
             searchView.queryTextChanges()
+                    .skipInitialValue()
                     .debounce(300)
                     .onEach { filterRoomsWith(it.toString()) }
                     .launchIn(viewLifecycleOwner.lifecycleScope)
@@ -309,8 +310,15 @@ class RoomListFragment @Inject constructor(
         roomListViewModel.handle(RoomListAction.FilterWith(filter))
     }
 
+<<<<<<< Updated upstream
     private fun resetFilter() {
         roomListViewModel.handle(RoomListAction.FilterWith(filter = ""))
+=======
+    private fun resetFilter() =  withState(roomListViewModel) { state ->
+        if (state.roomFilter.isNotEmpty()) {
+            filterRoomsWith("")
+        }
+>>>>>>> Stashed changes
     }
 
     // FilteredRoomFooterItem.Listener

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
@@ -309,8 +309,8 @@ class RoomListFragment @Inject constructor(
 
         roomListViewModel.handle(RoomListAction.FilterWith(filter))
     }
-    
-    private fun resetFilter() =  withState(roomListViewModel) { state ->
+
+    private fun resetFilter() = withState(roomListViewModel) { state ->
         if (state.roomFilter.isNotEmpty()) {
             filterRoomsWith("")
         }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
@@ -309,16 +309,11 @@ class RoomListFragment @Inject constructor(
 
         roomListViewModel.handle(RoomListAction.FilterWith(filter))
     }
-
-<<<<<<< Updated upstream
-    private fun resetFilter() {
-        roomListViewModel.handle(RoomListAction.FilterWith(filter = ""))
-=======
+    
     private fun resetFilter() =  withState(roomListViewModel) { state ->
         if (state.roomFilter.isNotEmpty()) {
             filterRoomsWith("")
         }
->>>>>>> Stashed changes
     }
 
     // FilteredRoomFooterItem.Listener

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
@@ -309,7 +309,9 @@ class RoomListFragment @Inject constructor(
         roomListViewModel.handle(RoomListAction.FilterWith(filter))
     }
 
-    private fun resetFilter() = filterRoomsWith("")
+    private fun resetFilter() {
+        roomListViewModel.handle(RoomListAction.FilterWith(filter = ""))
+    }
 
     // FilteredRoomFooterItem.Listener
     override fun createRoom(initialName: String) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content
#481 
We don't scroll to the position 0 when a room is opened/created
<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

https://user-images.githubusercontent.com/15031750/157635104-dea9c061-bf9a-4c4b-bcdc-92c8c0291531.mov

<!-- Only if UI have been changed -->

## Tests

<!-- Explain how you tested your development -->

- Open a room, no scroll before the opening.
- Create a room, no scroll before the opening

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [ ] Pull request updates [TCHAP_CHANGES.md](https://github.com/tchapgouv/tchap-android-v2/blob/develop/TCHAP_CHANGES.md)
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android-v2/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
