### PR TITLE
[Notification mode] Wrong mode is displayed when the mention only is selected on the web client

### DIFF
--- a/changelog.d/464.bugfix
+++ b/changelog.d/464.bugfix
@@ -1,0 +1,1 @@
+[Notification mode] Wrong mode is displayed when the mention only is selected on the web client

--- a/vector/src/main/java/im/vector/app/features/roomprofile/notifications/RoomNotificationSettingsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/notifications/RoomNotificationSettingsViewState.kt
@@ -42,10 +42,10 @@ val RoomNotificationSettingsViewState.notificationStateMapped: Async<RoomNotific
     get() {
         if ((roomSummary()?.isEncrypted == true && notificationState() == RoomNotificationState.MENTIONS_ONLY) ||
                 notificationState() == RoomNotificationState.ALL_MESSAGES) {
-            /** if in an encrypted room, mentions notifications are not supported so show "All Messages" as selected.
+            /** if in an encrypted room, mentions notifications are not supported so show "None" as selected.
              * Also in the new settings there is no notion of notifications without sound so it maps to noisy also
              */
-            return Success(RoomNotificationState.ALL_MESSAGES_NOISY)
+            return Success(RoomNotificationState.MUTE)
         }
         return  notificationState
     }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/notifications/RoomNotificationSettingsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/notifications/RoomNotificationSettingsViewState.kt
@@ -40,8 +40,7 @@ data class RoomNotificationSettingsViewState(
  */
 val RoomNotificationSettingsViewState.notificationStateMapped: Async<RoomNotificationState>
     get() {
-        if ((roomSummary()?.isEncrypted == true && notificationState() == RoomNotificationState.MENTIONS_ONLY) ||
-                notificationState() == RoomNotificationState.ALL_MESSAGES) {
+        if (roomSummary()?.isEncrypted == true && notificationState() == RoomNotificationState.MENTIONS_ONLY) {
             /** if in an encrypted room, mentions notifications are not supported so show "None" as selected.
              * Also in the new settings there is no notion of notifications without sound so it maps to noisy also
              */


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content
#464 
Use none in android application when all messages or mentions only is selected in the web application.
<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
Web:
<img width="446" alt="Capture d’écran 2022-03-10 à 13 33 48" src="https://user-images.githubusercontent.com/15031750/157662781-a45db37a-ae88-4467-8be5-6374cd478c8f.png">
Android:
![Screenshot_1646908994](https://user-images.githubusercontent.com/15031750/157646307-d85475da-d9e0-4d94-baec-7b224f74f10e.png)

<!-- Only if UI have been changed -->

## Tests

<!-- Explain how you tested your development -->

- Room created in the web app and update notification settings. The notification settings is set to none in the android application for the room. 

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request updates [TCHAP_CHANGES.md](https://github.com/tchapgouv/tchap-android-v2/blob/develop/TCHAP_CHANGES.md)
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#changelog
- [X] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android-v2/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
