### PR TITLE
Hotfix version 2.0.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,8 @@ jobs:
   release:
     name: Build unsigned ${{ matrix.target }} APKs
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    # Tchap: Generate apks on new tchap release
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/tchap_v')
     strategy:
       fail-fast: false
       matrix:

--- a/changelog.d/517.bugfix
+++ b/changelog.d/517.bugfix
@@ -1,0 +1,1 @@
+Fix SSL errors on some devices using fdroid version

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-    version = "2.0.3"
+    version = "2.0.4"
     directory = "changelog.d"
     filename = "TCHAP_CHANGES.md"
     name = "Changes in Tchap"

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -15,7 +15,7 @@ kapt {
 // Note: 2 digits max for each value
 ext.versionMajor = 2
 ext.versionMinor = 0
-ext.versionPatch = 3
+ext.versionPatch = 4
 
 static def getGitTimestamp() {
     def cmd = 'git show -s --format=%ct'

--- a/vector/src/withoutpinning/res/xml/network_security_config.xml
+++ b/vector/src/withoutpinning/res/xml/network_security_config.xml
@@ -1,35 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <!-- Ref: https://developer.android.com/training/articles/security-config.html -->
-    <!-- By default, do not allow clearText traffic -->
-    <base-config cleartextTrafficPermitted="false" />
-
-    <!-- Allow clearText traffic on some specified host -->
-    <domain-config cleartextTrafficPermitted="true">
-        <!-- Localhost -->
-        <domain includeSubdomains="true">localhost</domain>
-        <domain includeSubdomains="true">127.0.0.1</domain>
-        <!-- Localhost for Android emulator -->
-        <domain includeSubdomains="true">10.0.2.2</domain>
-        <!-- Onion services -->
-        <domain includeSubdomains="true">onion</domain>
-
-        <!-- Domains that are used for LANs -->
-        <!-- These are IANA recognized special use domain names, see https://www.iana.org/assignments/special-use-domain-names/special-use-domain-names.xhtml -->
-        <domain includeSubdomains="true">home.arpa</domain>
-        <domain includeSubdomains="true">local</domain> <!-- Note this has been reserved for use with mDNS -->
-        <domain includeSubdomains="true">test</domain>
-        <!-- These are observed in the wild either by convention or RFCs that have not been accepted, and are not currently TLDs -->
-        <domain includeSubdomains="true">home</domain>
-        <domain includeSubdomains="true">lan</domain>
-        <domain includeSubdomains="true">localdomain</domain>
-    </domain-config>
-
-    <debug-overrides>
+    <!-- Do not allow clearText traffic -->
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
+            <!-- Give access to the user certificate, as per default behaviour when targeting API 23 or lower -->
             <certificates src="user" />
         </trust-anchors>
-    </debug-overrides>
-
+    </base-config>
 </network-security-config>


### PR DESCRIPTION
#524 
This version fix pinning issues on some specific secure devices using the fdroid version of Tchap.
The fix is already included in Tchap v2.1.0, see #518 