### PR TITLE
Release Tchap-Android-v2.2.0

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,6 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         api-level: [ 28 ]
+    # Tchap: Disabled for now
+    if: github.repository == 'vector-im/element-android'
     # No concurrency required, runs every time on a schedule.
     steps:
       - uses: actions/checkout@v3
@@ -214,6 +216,8 @@ jobs:
       fail-fast: false
       matrix:
         api-level: [ 28 ]
+    # Tchap: Disabled for now
+    if: github.repository == 'vector-im/element-android'
     # No concurrency required, runs every time on a schedule.
     steps:
       - uses: actions/checkout@v3
@@ -267,6 +271,8 @@ jobs:
   codecov-units:
     name: Unit tests with code coverage
     runs-on: macos-latest
+    # Tchap: Disabled for now
+    if: github.repository == 'vector-im/element-android'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v2
@@ -293,7 +299,8 @@ jobs:
   sonarqube:
     name: Sonarqube upload
     runs-on: macos-latest
-    if: always()
+    # Tchap: Disabled for now
+    if: github.repository == 'vector-im/element-android'
     needs:
       - codecov-units
     steps:
@@ -327,7 +334,8 @@ jobs:
       - integration-tests
       - ui-tests
       - sonarqube
-    if: always() && github.event_name != 'workflow_dispatch'
+    # Tchap: Disabled for now
+    if: github.repository == 'vector-im/element-android'
     # No concurrency required, runs every time on a schedule.
     steps:
       - uses: michaelkaye/matrix-hookshot-action@v0.3.0

--- a/TCHAP_CHANGES.md
+++ b/TCHAP_CHANGES.md
@@ -1,3 +1,21 @@
+Changes in Tchap 2.2.0 (2022-04-12)
+===================================
+
+Improvements 🙌
+--------------
+ - [Settings] Add a link to the help page from Help&About screen ([#342](https://github.com/tchapgouv/tchap-android-v2/issues/342))
+
+Bugfixes 🐛
+----------
+ - Hide sticker button ([#520](https://github.com/tchapgouv/tchap-android-v2/issues/520))
+ - Fix wrong application name in release build ([#521](https://github.com/tchapgouv/tchap-android-v2/issues/521))
+
+Other changes
+-------------
+ - Rebase against version v1.4.8 ([#497](https://github.com/tchapgouv/tchap-android-v2/issues/497))
+ - Hide/Disable unwanted features from Element: polls, location sharing, analytics(PostHog) ([#404](https://github.com/tchapgouv/tchap-android-v2/issues/404))
+
+
 Changes in Tchap 2.1.0 (2022-03-29)
 ===================================
 

--- a/changelog.d/342.improvements
+++ b/changelog.d/342.improvements
@@ -1,1 +1,0 @@
-[Settings] Add a link to a help page from Help&About screen

--- a/changelog.d/497.misc
+++ b/changelog.d/497.misc
@@ -1,1 +1,0 @@
-Rebase against version v1.4.8

--- a/changelog.d/520.bugfix
+++ b/changelog.d/520.bugfix
@@ -1,1 +1,0 @@
-Hide sticker button

--- a/changelog.d/521.bugfix
+++ b/changelog.d/521.bugfix
@@ -1,1 +1,0 @@
-Fix wrong application name in release build


### PR DESCRIPTION
Nightly tests coming from Element introduced by #538 have been disabled for this release, especially because of issues related to the setup of synapse.